### PR TITLE
Implement new build process, enabling continuous integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 ehthumbs.db
 Thumbs.db
 DalaFloda*
+dist/*
 
 # Created by https://www.gitignore.io/api/node
 ### Node ###

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ehthumbs.db
 Thumbs.db
 DalaFloda*
 dist/*
+hgnm-2014.zip
 
 # Created by https://www.gitignore.io/api/node
 ### Node ###

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-language: php
-php:
-- '5.5'
-- '5.4'
+language: node_js
 node_js:
 - '4'
 - '4.2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,13 @@ install:
   - npm install
 script:
   - npm run build
+deploy:
+  provider: releases
+  api_key:
+    secure: CJa6+7F3KMRxjwdAx/4zgLU55l1uUE3CPUN0ezitehbcJX+yQoKfM0LevIgZw2UVjyGD3xXttTe3YDG0ypG9jqqxhJSa3bA7dV9OnP4+rY/vPvjZLRmBTqSjb5S/d4oB78l4hxgxw7+RuwEr0DXhaFJ4BzJ00zplQ9TAmlPOZPs=
+  file: hgnm-2014.zip
+  skip_cleanup: true
+  on:
+    repo: HGNM/hgnm-2014
+    tags: true
+    node: '4.2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: php
+php:
+- '5.5'
+- '5.4'
+install:
+  - ./install-dependencies.sh
+  - npm install
+script:
+  - npm run css:build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 php:
 - '5.5'
 - '5.4'
+node_js:
+- '4'
+- '4.2'
+- '5.1'
 install:
   - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
 - '5.5'
 - '5.4'
 install:
-  - ./install-dependencies.sh
   - npm install
 script:
-  - npm run css:build
+  - npm run build

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Check all required CLIs are available
+dependencies=( wget unzip )
+for dependency in "${dependencies[@]}"; do
+  command -v $dependency >/dev/null 2>&1 || { echo >&2 "‘$dependency’ command is required but it’s not installed. Aborting."; exit 1; }
+done
+
+# Get required proprietary fonts for theme
+wget -O df.zip "http://chrisswithinbank.net/wp-content/uploads/2016/06/1407-HRGQJV.zip"
+if [[ -f "df.zip" ]]; then
+  unzip df.zip -d font/
+  rm df.zip
+else
+  echo "Can’t find file: df.zip. Fatal error…"
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Repository for WordPress theme development for hgnm.org",
   "scripts": {
     "start": "npm run css:build && npm run css:watch",
+    "build": "npm run css:build && npm run bundle",
     "css:build": "node-sass --include-path scss scss/style.scss style.css",
-    "css:watch": "node-sass --include-path scss scss/style.scss style.css -w"
+    "css:watch": "node-sass --include-path scss scss/style.scss style.css -w",
+    "bundle": "bestzip hgnm-2014.zip /"
   },
   "repository": "HGNM/hgnm-2014",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.8.0",
   "description": "Repository for WordPress theme development for hgnm.org",
   "scripts": {
-    "start": "npm run copy && npm run css:build && npm run css:watch",
-    "build": "npm run copy && npm run css:build && npm run zip",
-    "css:build": "node-sass --include-path scss scss/style.scss dist/style.css",
-    "css:watch": "node-sass --include-path scss scss/style.scss dist/style.css -w",
+    "start": "npm run css:build && npm run css:watch",
+    "build": "npm run css:build && npm run copy && npm run zip",
+    "css:build": "node-sass --include-path scss scss/style.scss style.css",
+    "css:watch": "node-sass --include-path scss scss/style.scss style.css -w",
     "copy": "cpy '**/*' '!scss/*' '!dist/*' 'dist/' --parents --nodir",
     "zip": "bestzip hgnm-2014.zip dist/",
     "postinstall": "./install-dependencies.sh"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/HGNM/hgnm-2014#readme",
   "devDependencies": {
+    "bestzip": "^1.1.3",
     "node-sass": "^3.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/HGNM/hgnm-2014#readme",
   "devDependencies": {
     "bestzip": "^1.1.3",
+    "cpy-cli": "^1.0.1",
     "node-sass": "^3.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "bestzip": "^1.1.3",
     "cpy-cli": "git+https://github.com/chimon2000/cpy-cli.git",
     "node-sass": "^3.7.0"
+  },
+  "engines": {
+    "node": ">=4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "start": "npm run copy && npm run css:build && npm run css:watch",
     "build": "npm run copy && npm run css:build && npm run zip",
-    "css:build": "node-sass --include-path src/scss src/scss/style.scss dist/style.css",
-    "css:watch": "node-sass --include-path src/scss src/scss/style.scss dist/style.css -w",
-    "copy": "cpy '**/*' '!scss/*' '../dist/' --cwd=src --parents --nodir",
+    "css:build": "node-sass --include-path scss scss/style.scss dist/style.css",
+    "css:watch": "node-sass --include-path scss scss/style.scss dist/style.css -w",
+    "copy": "cpy '**/*' '!scss/*' '!dist/*' 'dist/' --parents --nodir",
     "zip": "bestzip hgnm-2014.zip dist/",
     "postinstall": "./install-dependencies.sh"
   },

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Repository for WordPress theme development for hgnm.org",
   "scripts": {
     "start": "npm run css:build && npm run css:watch",
-    "build": "npm run css:build && npm run bundle",
-    "css:build": "node-sass --include-path scss scss/style.scss style.css",
-    "css:watch": "node-sass --include-path scss scss/style.scss style.css -w",
-    "bundle": "bestzip hgnm-2014.zip /"
+    "build": "npm run copy && npm run css:build && npm run zip",
+    "css:build": "node-sass --include-path src/scss src/scss/style.scss dist/style.css",
+    "css:watch": "node-sass --include-path src/scss src/scss/style.scss dist/style.css -w",
+    "copy": "cpy '**/*' '!scss/*' '../dist/' --cwd=src --parents --nodir",
+    "zip": "bestzip hgnm-2014.zip dist/",
+    "postinstall": "./install-dependencies.sh"
   },
   "repository": "HGNM/hgnm-2014",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "npm run css:build && npm run copy && npm run zip",
     "css:build": "node-sass --include-path scss scss/style.scss style.css",
     "css:watch": "node-sass --include-path scss scss/style.scss style.css -w",
-    "copy": "cpy '**/*' '!scss/*' '!dist/*' 'dist/' --parents --nodir",
+    "copy": "cpy '**/*' '!scss/*' '!dist/*' '!.gitignore' '!.travis.yml' '!install-dependencies.sh' '!node_modules/**/*' '!hgnm-2014.zip' 'dist/' --parents --nodir",
     "zip": "bestzip hgnm-2014.zip dist/",
     "postinstall": "./install-dependencies.sh"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/HGNM/hgnm-2014#readme",
   "devDependencies": {
     "bestzip": "^1.1.3",
-    "cpy-cli": "github:chimon2000/cpy-cli",
+    "cpy-cli": "git+https://github.com/chimon2000/cpy-cli.git",
     "node-sass": "^3.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.0",
   "description": "Repository for WordPress theme development for hgnm.org",
   "scripts": {
-    "start": "npm run css:build && npm run css:watch",
+    "start": "npm run copy && npm run css:build && npm run css:watch",
     "build": "npm run copy && npm run css:build && npm run zip",
     "css:build": "node-sass --include-path src/scss src/scss/style.scss dist/style.css",
     "css:watch": "node-sass --include-path src/scss src/scss/style.scss dist/style.css -w",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/HGNM/hgnm-2014#readme",
   "devDependencies": {
     "bestzip": "^1.1.3",
-    "cpy-cli": "^1.0.1",
+    "cpy-cli": "github:chimon2000/cpy-cli",
     "node-sass": "^3.7.0"
   }
 }


### PR DESCRIPTION
* More elaborate build scripts copy deployment files to `dist/` and compress it to `hgnm-2014.zip` in root.

* Required fonts are fetched after `npm install`.

* Compatible with Travis CI.

* Starts to potentially address #7 if Travis can deploy `hgnm-2014.zip` to releases.