### PR TITLE
feat: Add options for colloquium location & front page links

### DIFF
--- a/components/colloquium_location_link.php
+++ b/components/colloquium_location_link.php
@@ -12,10 +12,12 @@ if (!function_exists('colloquium_location_link')) {
         $classes = $location_only ? 'location map-popup' : 'map-popup';
 
         $html = '<p class="' . $classes . '">';
-        if (!$location_only) {
-            $html .= 'All colloquia are at 12pm in ';
+        if ($location_only) {
+            $html .= get_field('colloquium_location_short', 'option');
+        } else {
+            $html .= get_field('colloquium_location_long', 'option');
         }
-        $html .= 'Room 6, <a href="https://www.google.com/maps/place/Music+Bldg,+Harvard+University,+Cambridge,+MA+02138/@42.3769058,-71.1170215,15z/data=!4m2!3m1!1s0x89e3774164253f4d:0x4139366065ac28ee">' .
+        $html .= ', <a href="https://www.google.com/maps/place/Music+Bldg,+Harvard+University,+Cambridge,+MA+02138/@42.3769058,-71.1170215,15z/data=!4m2!3m1!1s0x89e3774164253f4d:0x4139366065ac28ee">' .
           'Harvard University Music Building' .
           component('icon', array('type' => 'location')) .
         '</a>';

--- a/front-page.php
+++ b/front-page.php
@@ -15,7 +15,7 @@ get_header();
               'button_link',
               array(
                 'href' => 'https://www.facebook.com/pages/Harvard-Group-for-New-Music/130937206919388',
-                'html' => 'Join us on Facebook' . component('icon', array('type' => 'facebook'))
+                'html' => get_field('front_page_facebook_link_text', 'option') . component('icon', array('type' => 'facebook'))
               )
             ) ?>
           </p>
@@ -184,7 +184,7 @@ get_header();
       <div class="fp-archive-link">
         <?= component('button_link', array(
           'href' => get_post_type_archive_link('concert'),
-          'html' => '<h2>Archive</h2><p>Dive into an archive of HGNM’s past events, members, audio and video.</p>'
+          'html' => '<h2>Archive</h2><p>' . get_field('front_page_archive_link_text', 'option') . '</p>'
         )) ?>
       </div>
     </section>

--- a/functions.php
+++ b/functions.php
@@ -42,5 +42,8 @@ $example_update_checker = new ThemeUpdateChecker(
 // Set up Advanced Custom Fields field groups
 include('functions/acf-field-groups.php');
 
+// Set up Advanced Custom Fields theme options page
+include('functions/acf-theme-options.php');
+
  // Disable wp-emoji
 include('functions/disable-wp-emoji.php');

--- a/functions/acf-theme-options.php
+++ b/functions/acf-theme-options.php
@@ -1,0 +1,119 @@
+<?php
+function hgnm_theme_options()
+{
+    // Add an options page with hgnm-2014 theme settings
+    if (function_exists('acf_add_options_page')) {
+        acf_add_options_page(array(
+            'page_title' => 'HGNM Theme Options',
+            'menu_title' => 'HGNM Options',
+            'menu_slug'  => 'theme-options',
+            'capability' => 'edit_theme_options',
+            'redirect'   => false,
+            'position'   => '59.5'
+        ));
+    }
+
+    // Register custom fields group for options page
+    if (function_exists('acf_add_local_field_group')) {
+        acf_add_local_field_group(array(
+            'key' => 'group_5c7196bbe61a4',
+            'title' => 'Theme Options',
+            'fields' => array(
+                array(
+                    'key' => 'field_5c7196ea902e8',
+                    'label' => 'Colloquium Location (short)',
+                    'name' => 'colloquium_location_short',
+                    'type' => 'text',
+                    'instructions' => 'This will be display the colloquium location on upcoming colloquia pages, e.g. “Room 6”',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => array(
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ),
+                    'default_value' => 'Davison Room',
+                    'placeholder' => 'Davison Room',
+                    'prepend' => '',
+                    'append' => ', Harvard University Music Building',
+                    'maxlength' => '',
+                ),
+                array(
+                    'key' => 'field_5c71972c902e9',
+                    'label' => 'Colloquium Time & Location (long)',
+                    'name' => 'colloquium_location_long',
+                    'type' => 'text',
+                    'instructions' => 'This will display colloquium information below the upcoming colloquia list on the home page and on the events page, e.g. “All colloquia are at 12pm in Room 6”',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => array(
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ),
+                    'default_value' => 'All colloquia are at 12pm in the Davison Room',
+                    'placeholder' => 'All colloquia are at 12pm in the Davison Room',
+                    'prepend' => '',
+                    'append' => ', Harvard University Music Building',
+                    'maxlength' => '',
+                ),
+                array(
+                    'key' => 'field_5c719a8d6ef4c',
+                    'label' => 'Front Page Facebook Link Text',
+                    'name' => 'front_page_facebook_link_text',
+                    'type' => 'text',
+                    'instructions' => 'This is the text that will be shown on the link to the HGNM Facebook page on the home page. It will be followed by a Facebook logo icon.',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => array(
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ),
+                    'default_value' => 'Join us on Facebook',
+                    'placeholder' => 'Join us on Facebook',
+                    'prepend' => '',
+                    'append' => '',
+                    'maxlength' => '',
+                ),
+                array(
+                    'key' => 'field_5c7199e7c0ce0',
+                    'label' => 'Front Page Archive Link Text',
+                    'name' => 'front_page_archive_link_text',
+                    'type' => 'text',
+                    'instructions' => 'This text will be displayed on the large archive link at the bottom of the home page, e.g. “Dive into an archive of HGNM’s past events, members, audio and video.”',
+                    'required' => 0,
+                    'conditional_logic' => 0,
+                    'wrapper' => array(
+                        'width' => '',
+                        'class' => '',
+                        'id' => '',
+                    ),
+                    'default_value' => 'Dive into an archive of HGNM’s past events, members, audio and video.',
+                    'placeholder' => 'Dive into an archive of HGNM’s past events, members, audio and video.',
+                    'prepend' => '',
+                    'append' => '',
+                    'maxlength' => '',
+                ),
+            ),
+            'location' => array(
+                array(
+                    array(
+                        'param' => 'options_page',
+                        'operator' => '==',
+                        'value' => 'theme-options',
+                    ),
+                ),
+            ),
+            'menu_order' => 0,
+            'position' => 'normal',
+            'style' => 'seamless',
+            'label_placement' => 'top',
+            'instruction_placement' => 'label',
+            'hide_on_screen' => '',
+            'active' => 1,
+            'description' => 'These options allow users to configure site-wide content and vocabulary',
+        ));
+    }
+}
+add_action('acf/init', 'hgnm_theme_options');


### PR DESCRIPTION
This uses ACF’s [options page](https://www.advancedcustomfields.com/resources/options-page/) feature to add easier control for some text, specifically:

- Text used for colloquium location and time
- Text used for Facebook link on home page
- Text used for archive link at the bottom of the home page